### PR TITLE
Add the recent NousResearch Hermes Llama3 variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 *.DS_Store
 ./utils.txt
 local/*
+
+# Jetbrains IDEs
+.idea/

--- a/src/mlx_llm/model/_registry.py
+++ b/src/mlx_llm/model/_registry.py
@@ -173,6 +173,42 @@ def llama_3_8b_instruct(
     )
     return model, config
 
+@register_model("hermes_2_pro_llama_3_8b_instruct")
+def llama_3_8b_instruct(
+        vocab_size: int = 128288, norm_eps: float = 1e-5, rope_theta: float = 500000.0, rope_traditional: bool = False
+) -> Tuple[Transformer, ModelConfig]:
+    """Create a LLaMA 3 8B Instruct model.
+
+    Args:
+        vocab_size (int, optional): vocab size. Defaults to 128256.
+        norm_eps (float, optional): norm epsilon. Defaults to 1e-5.
+        rope_theta (int, optional): rope theta. Defaults to 500000.0.
+        rope_traditional (bool, optional): whether to use traditional rope. Defaults to False.
+
+    Returns:
+        Tuple[Transformer, ModelConfig]: model, config
+    """
+
+    model = Transformer(
+        dim=4096,
+        hidden_dim=14336,
+        vocab_size=vocab_size,
+        n_layers=32,
+        n_heads=32,
+        n_kv_heads=8,
+        norm_eps=norm_eps,
+        rope_theta=rope_theta,
+        rope_traditional=rope_traditional,
+    )
+
+    config = ModelConfig(
+        hf=HFConfig(
+            repo_id="NousResearch/Hermes-2-Pro-Llama-3-8B",
+        ),
+        converter=llama_to_mlxllm,
+    )
+    return model, config
+
 
 @register_model("phi_3_mini_4k_instruct")
 def phi3_mini_4k_instruct(

--- a/src/mlx_llm/model/_registry.py
+++ b/src/mlx_llm/model/_registry.py
@@ -177,10 +177,10 @@ def llama_3_8b_instruct(
 def llama_3_8b_instruct(
         vocab_size: int = 128288, norm_eps: float = 1e-5, rope_theta: float = 500000.0, rope_traditional: bool = False
 ) -> Tuple[Transformer, ModelConfig]:
-    """Create a LLaMA 3 8B Instruct model.
+    """Create a Hermes 2 Pro LLaMA 3 8B Instruct model.
 
     Args:
-        vocab_size (int, optional): vocab size. Defaults to 128256.
+        vocab_size (int, optional): vocab size. Defaults to 128288.
         norm_eps (float, optional): norm epsilon. Defaults to 1e-5.
         rope_theta (int, optional): rope theta. Defaults to 500000.0.
         rope_traditional (bool, optional): whether to use traditional rope. Defaults to False.


### PR DESCRIPTION
Adding support for the model found here - https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B

> Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.

